### PR TITLE
初期改善

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-microtonia.github.io.tst

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+microtonia.github.io.tst

--- a/index.html
+++ b/index.html
@@ -202,6 +202,11 @@
 	<nav>
 		<span id="tone-caption">　Yamaha C5, Alexander Holm, CC BY 3.0</span>
 	</nav>
+	<nav>
+		<span class="max" data-i18n="project">工程</span>
+		<button id="save-project-btn" class="round small" data-i18n="save">保存</button>
+		<button id="load-project-btn" class="round small" data-i18n="load">加载</button>
+	</nav>
 </article>
 <div id="snackbar" class="snackbar primary">
 	<div id="snackbar-text" class="max" data-i18n="copy-finish">コピー完了</div>

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,7 +1,6 @@
 
 import { $, range, hz2y, x2t, t2x, f2d, qh, OFFSET } from './util.js'
 import { rootlayer } from './sequencer.js'
-
 export class Grid extends Konva.Layer {
 	constructor(stage, tonic, beat) {
 		super() // {listening: false})

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,5 +1,6 @@
 
 import { $, range, hz2y, x2t, t2x, f2d, qh, OFFSET } from './util.js'
+import { rootlayer } from './sequencer.js'
 
 export class Grid extends Konva.Layer {
 	constructor(stage, tonic, beat) {
@@ -185,5 +186,25 @@ export class Grid extends Konva.Layer {
 	setLoop() {
 		Tone.Transport.loopStart = x2t(this.loopStart.x()) + OFFSET + "i"
 		Tone.Transport.loopEnd = x2t(this.loopEnd.x()) + OFFSET + "i"
+	}
+
+	// 自动将循环箭头分配到最左/最右音符
+	autoLoop() {
+		const children = rootlayer.getChildren()
+		if (children.length === 0) return
+
+		let minX = Infinity, maxX = -Infinity
+		for (const note of children) {
+			const x = note.x()
+			const len = note.len || 48
+			if (x < minX) minX = x
+			if (x + len > maxX) maxX = x + len
+		}
+
+		const pad = 48  // 1拍间距
+		this.loopStart.x(minX - pad)
+		this.loopEnd.x(maxX + pad)
+		this.setLoop()
+		this.batchDraw()
 	}
 }

--- a/js/grid.js
+++ b/js/grid.js
@@ -5,8 +5,8 @@ export class Grid extends Konva.Layer {
 	constructor(stage, tonic, beat) {
 		super() // {listening: false})
 		this.stage = stage
-		this._tonic = tonic
-		this._beat = beat
+		this._tonic = tonic || 440
+		this._beat = beat || 500
 		this.octave = f2d(1, 2)
 		
 		this.scorelines = new Konva.Group()

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -30,7 +30,10 @@ const tr = {
 		"base-note": "底音",
 		"other-note": "その他",
 		"tone": "音色",
-		"copy-finish": "コピー完了"
+		"copy-finish": "コピー完了",
+		"project": "プロジェクト",
+		"save": "保存",
+		"load": "読み込み"
 	},
 	'en': {
 		"prog": "[Progress]",
@@ -52,7 +55,10 @@ const tr = {
 		"base-note": "Base Notes",
 		"other-note": "Others",
 		"tone": "Instrument",
-		"copy-finish": "Copied"
+		"copy-finish": "Copied",
+		"project": "Project",
+		"save": "Save",
+		"load": "Load"
 	},
 	'sf': {
 		"prog": "[Clyftach]",
@@ -74,6 +80,9 @@ const tr = {
 		"base-note": "Lystalipam",
 		"other-note": "Fynächam",
 		"tone": "Vlesyvom",
-		"copy-finish": "Na chlacrapham"
+		"copy-finish": "Na chlacrapham",
+		"project": "Clypmelyt",
+		"save": "Plych",
+		"load": "Tatcha"
 	},
 }

--- a/js/serialize.js
+++ b/js/serialize.js
@@ -1,49 +1,27 @@
-/*
- * 工程文件序列化与反序列化模块 — 支持 JSON/JSONCrush 压缩、版本兼容、历史快照与分享
- * プロジェクトファイルのシリアライズ・デシリアライズモジュール — JSON/JSONCrush圧縮、バージョン互換、履歴スナップショットと共有をサポート
- * Project file serialization/deserialization module — supports JSON/JSONCrush compression, version compatibility, history snapshots, and sharing
- */
-
 import {$, t2x, x2t, hz2y, pitchIntervals} from './util.js'
 import {RootNote, SubNote} from './note.js'
 import JSONCrush from 'https://unpkg.com/jsoncrush'
 import {stage, grid, rootlayer} from './sequencer.js'
 
-// Hz精度倍率（v1=16, v2=256），低音区误差从 5¢ 降到 0.03¢
-// Hz精度乗数（v1=16, v2=256）、低音域の誤差を5¢から0.03¢に低減
-const HZ_MUL = 256           // Hz precision multiplier (v1=16, v2=256), reduces low-frequency error from 5¢ to 0.03¢
+const HZ_MUL = 16
 
-// 序列化器类：将音符工程数据与 JSON 之间相互转换
-// シリアライザークラス：音符プロジェクトデータとJSONの相互変換を行う
-// Serializer class: converts note project data to/from JSON
 export class Serializer {
-	// 序列化主入口：将当前工程序列化为 JSON 字符串（可选 crush 压缩）
-	// シリアライズメインエントリ：現在のプロジェクトをJSON文字列にシリアライズ（オプションでcrush圧縮）
-	// Main serialize entry: serializes current project to JSON string (optional crush compression)
-	static serialize(savegrid, crush = true) {
+	static serialize(savegrid) {
 		const s = savegrid ? {
-			v: 2,
 			b: grid.beat,
 			t: grid.tonic,
 			s: x2t(grid.loopStart.x()),
 			e: x2t(grid.loopEnd.x()),
-			i: $('#config-tone').value,
-			o: rootlayer.opacity()
-		} : { v: 2, o: rootlayer.opacity() }   // 历史快照也带版本标记，避免反序列化时 hzDiv 回退到 16 / 履歴スナップショットにもバージョンタグを付与、デシリアライズ時のhzDiv後退を防止 / History snapshots also carry version tag to prevent hzDiv fallback to 16
+			i: $('#config-tone').value
+		} : false
 		const n = rootlayer.children.map(x => this.root2json(x))
-		const json = JSON.stringify(
+		const c = JSONCrush.crush(JSON.stringify(
 			{s: s, n: n}, 
 			(k, v) => (!v || v.length == 0) ? undefined : v
-		)
-		// 分享/保存用 crush 压缩 URL；历史快照用纯 JSON 避免 CPU 开销
-		// 共有・保存用にcrush圧縮URL；履歴スナップショットは純粋なJSONでCPUオーバーヘッドを回避
-		// Crush-compressed URL for sharing/saving; plain JSON for history snapshots to avoid CPU overhead
-		return crush ? encodeURIComponent(JSONCrush.crush(json)) : json
+		))
+		return encodeURIComponent(c)
 	}
 
-	// 将根音符序列化为 JSON 对象
-	// ルート音符をJSONオブジェクトにシリアライズ
-	// Serialize a root note to a JSON object
 	static root2json(note) {
 		return {
 			x: Math.round(note.x() * 4),
@@ -51,18 +29,9 @@ export class Serializer {
 			h: Math.round(note.hz * HZ_MUL),
 			m: note.mute,
 			v: note.volume - 50,
-			hd: note.hidden ? 1 : 0,
-			pt: note._pitchThick,
-			lt: note._linkThick,
-			lo: note._linkOpacity,
-			no: note._noteOpacity,
-			tk: note._tick,
 			s: note.childNotes.children.map(x => this.sub2json(x))
 		}
 	}
-	// 将子音符序列化为 JSON 对象（递归）
-	// サブ音符をJSONオブジェクトにシリアライズ（再帰的）
-	// Serialize a sub-note to a JSON object (recursive)
 	static sub2json(note) {
 		return {
 			i: note.interval.id,
@@ -71,31 +40,16 @@ export class Serializer {
 			h: Math.round(note._hz * HZ_MUL),
 			m: note.mute,
 			v: note.volume - 50,
-			hd: note.hidden ? 1 : 0,
-			pt: note._pitchThick,
-			lt: note._linkThick,
-			lo: note._linkOpacity,
-			no: note._noteOpacity,
-			tk: note._tick,
 			s: note.childNotes.children.map(x => this.sub2json(x))
 		}
 	}
-	// 从 JSON 反序列化根音符字符串重建工程（自动检测纯 JSON 或 crush 压缩格式）
-	// デシリアライズ：JSON文字列からプロジェクトを再構築（純粋JSONまたはcrush圧縮形式を自動検出）
-	// Deserialize from JSON string: rebuild project (auto-detect plain JSON or crush-compressed format)
+
 	static deserialize(d) {
 		let u
-		// 先尝试纯 JSON（历史快照），失败则尝试 URL解码+JSONCrush解压（分享/文件）
-		// まず純粋JSON（履歴スナップショット）を試行、失敗時はURLデコード+JSONCrush解凍（共有/ファイル）
-		// Try plain JSON first (history snapshots); on failure, try URL-decode + JSONCrush decompress (sharing/file)
 		try { u = JSON.parse(d) }
 		catch { u = JSON.parse(JSONCrush.uncrush(decodeURIComponent(d))) }
-		// 版本感知：v2 用 HZ_MUL=256，旧文件用 16
-		// バージョン認識：v2はHZ_MUL=256、旧ファイルは16を使用
-		// Version-aware: v2 uses HZ_MUL=256, old files use 16
-		const hzDiv = (u.s && u.s.v >= 2) ? HZ_MUL : 16
 		
-		if (u.s && u.s.b != null) {   // 仅当包含实际工程设置（beat/tonic）而非仅版本标记 / 実際のプロジェクト設定（beat/tonic）を含む場合のみ、バージョンタグだけではない / Only when containing actual project settings (beat/tonic), not just version marker
+		if (u.s) {
 			grid.beat = u.s.b
 			grid.tonic = u.s.t
 			grid.loopStart.x(t2x(u.s.s || 0))
@@ -104,66 +58,34 @@ export class Serializer {
 			$(`#config-tone>option[value='${u.s.i || "salamander-piano"}']`).selected = true
 			$('#config-tone').dispatchEvent(new Event('change'))
 		}
-		// 恢复 layer 级透明度，避免 Ctrl+Z 后音符透明度丢失
-		if (u.s && u.s.o != null) rootlayer.opacity(u.s.o)
 		if (!u.n) return
 		for (const n of u.n) {
-			const p = new RootNote(stage, n.x / 4 || 0, hz2y(n.h / hzDiv), n.l / 4, null, null, n.tk)
-			p.mute = n.m || false
-			p.volume = 50 + (n.v || 0)
-			// 恢复外观属性 / 外観属性を復元 / Restore visual properties
-			p._pitchThick = n.pt || p._pitchThick
-			p._linkThick = n.lt || p._linkThick
-			p._linkOpacity = n.lo || p._linkOpacity
-			p._noteOpacity = n.no ?? p._noteOpacity
-			p._tick = n.tk || p._tick
-			p.pitchline.strokeWidth(p._pitchThick)
-			p.pitchline.opacity(p._noteOpacity)
-			if (p.mark) p.mark.opacity(p._noteOpacity)
-			// 恢复隐藏状态（必须在 pitchline.opacity 之后，否则会被覆盖）// 非表示状態を復元（pitchline.opacityの後でないと上書きされる）// Restore hidden state (must be after pitchline.opacity to avoid overwrite)
-			p.hidden = !!(n.hd)
-			if (p._linkThick !== 1 || p._linkOpacity !== 1) p.applyLinkStyle()
-			rootlayer.add(p)
-			for (const m of n.s || []) {
-				this.json2sub(p, m, hzDiv)
-			}
+			this.json2root(n)
 		}
 	}
-
-	// 从 JSON 递归重建子音符
-	// JSONからサブ音符を再帰的に再構築
-	// Recursively rebuild sub-notes from JSON
-	static json2sub(p, m, hzDiv = 16) {
+	
+	static json2root(n) {
+		const p = new RootNote(stage, n.x / 4 || 0, hz2y(n.h / HZ_MUL), n.l / 4)
+		p.mute = n.m || false
+		p.volume = 50 + (n.v || 0)
+		rootlayer.add(p)
+		for (const m of n.s || []) {
+			this.json2sub(p, m)
+		}
+		return p
+	}
+	
+	static json2sub(p, m) {
 		const id = m.i || 0
-		// 音程键算法：将整数 ID 映射到音程字典的字符串键
-		//   id ≥ 100 → "c(id-100)"（正向自定义） / 正方向カスタム / positive custom
-		//   id ≤ -100 → "-c(-id-100)"（反向自定义） / 逆方向カスタム / negative custom  
-		//   否则 → "id d"（标准维度）
-		// 音程キーアルゴリズム：整数IDを音程辞書の文字列キーにマッピング
-		// Interval key algorithm: maps integer ID to string key in the interval dictionary
-		let key
-		if (id >= 100) key = 'c' + (id - 100)
-		else if (id <= -100) key = '-c' + (-id - 100)
-		else key = id + 'd'
+		const key = id + 'd'
 		const interval = pitchIntervals[key]
 		if (!interval) return
 		const q = p.addNote(m.l / 4, interval, m.d / 4 || 0)
 		q.mute = m.m || false
 		q.volume = 50 + (m.v || 0)
-		if (m.h) q.hz = m.h / hzDiv
-		// 恢复外观属性 / 外観属性を復元 / Restore visual properties
-		q._pitchThick = m.pt || q._pitchThick
-		q._linkThick = m.lt || q._linkThick
-		q._linkOpacity = m.lo || q._linkOpacity
-		q._noteOpacity = m.no ?? q._noteOpacity
-		q._tick = m.tk || q._tick
-		q.pitchline.strokeWidth(q._pitchThick)
-		q.pitchline.opacity(q._noteOpacity)
-		// 恢复隐藏状态（必须在 pitchline.opacity 之后，否则会被覆盖）
-		q.hidden = !!(m.hd)
-		if (q.linkLine) q.linkLine.opacity(q._linkOpacity)
+		if (m.h) q.hz = m.h / HZ_MUL
 		for (const l of m.s || []) {
-			this.json2sub(q, l, hzDiv)
+			this.json2sub(q, l)
 		}
 	}
 }

--- a/js/serialize.js
+++ b/js/serialize.js
@@ -1,54 +1,101 @@
+/*
+ * 工程文件序列化与反序列化模块 — 支持 JSON/JSONCrush 压缩、版本兼容、历史快照与分享
+ * プロジェクトファイルのシリアライズ・デシリアライズモジュール — JSON/JSONCrush圧縮、バージョン互換、履歴スナップショットと共有をサポート
+ * Project file serialization/deserialization module — supports JSON/JSONCrush compression, version compatibility, history snapshots, and sharing
+ */
 
 import {$, t2x, x2t, hz2y, pitchIntervals} from './util.js'
 import {RootNote, SubNote} from './note.js'
 import JSONCrush from 'https://unpkg.com/jsoncrush'
 import {stage, grid, rootlayer} from './sequencer.js'
 
+// Hz精度倍率（v1=16, v2=256），低音区误差从 5¢ 降到 0.03¢
+// Hz精度乗数（v1=16, v2=256）、低音域の誤差を5¢から0.03¢に低減
+const HZ_MUL = 256           // Hz precision multiplier (v1=16, v2=256), reduces low-frequency error from 5¢ to 0.03¢
+
+// 序列化器类：将音符工程数据与 JSON 之间相互转换
+// シリアライザークラス：音符プロジェクトデータとJSONの相互変換を行う
+// Serializer class: converts note project data to/from JSON
 export class Serializer {
-	static serialize(savegrid) {
+	// 序列化主入口：将当前工程序列化为 JSON 字符串（可选 crush 压缩）
+	// シリアライズメインエントリ：現在のプロジェクトをJSON文字列にシリアライズ（オプションでcrush圧縮）
+	// Main serialize entry: serializes current project to JSON string (optional crush compression)
+	static serialize(savegrid, crush = true) {
 		const s = savegrid ? {
+			v: 2,
 			b: grid.beat,
 			t: grid.tonic,
 			s: x2t(grid.loopStart.x()),
 			e: x2t(grid.loopEnd.x()),
-			i: $('#config-tone').value
-		} : false
+			i: $('#config-tone').value,
+			o: rootlayer.opacity()
+		} : { v: 2, o: rootlayer.opacity() }   // 历史快照也带版本标记，避免反序列化时 hzDiv 回退到 16 / 履歴スナップショットにもバージョンタグを付与、デシリアライズ時のhzDiv後退を防止 / History snapshots also carry version tag to prevent hzDiv fallback to 16
 		const n = rootlayer.children.map(x => this.root2json(x))
-//		console.log('serialized:', n)
-		const c = JSONCrush.crush(JSON.stringify(
+		const json = JSON.stringify(
 			{s: s, n: n}, 
 			(k, v) => (!v || v.length == 0) ? undefined : v
-		))
-		return encodeURIComponent(c)
+		)
+		// 分享/保存用 crush 压缩 URL；历史快照用纯 JSON 避免 CPU 开销
+		// 共有・保存用にcrush圧縮URL；履歴スナップショットは純粋なJSONでCPUオーバーヘッドを回避
+		// Crush-compressed URL for sharing/saving; plain JSON for history snapshots to avoid CPU overhead
+		return crush ? encodeURIComponent(JSONCrush.crush(json)) : json
 	}
 
+	// 将根音符序列化为 JSON 对象
+	// ルート音符をJSONオブジェクトにシリアライズ
+	// Serialize a root note to a JSON object
 	static root2json(note) {
 		return {
 			x: Math.round(note.x() * 4),
 			l: Math.round(note.len * 4),
-			h: Math.round(note.hz * 16),
+			h: Math.round(note.hz * HZ_MUL),
 			m: note.mute,
 			v: note.volume - 50,
+			hd: note.hidden ? 1 : 0,
+			pt: note._pitchThick,
+			lt: note._linkThick,
+			lo: note._linkOpacity,
+			no: note._noteOpacity,
+			tk: note._tick,
 			s: note.childNotes.children.map(x => this.sub2json(x))
 		}
 	}
+	// 将子音符序列化为 JSON 对象（递归）
+	// サブ音符をJSONオブジェクトにシリアライズ（再帰的）
+	// Serialize a sub-note to a JSON object (recursive)
 	static sub2json(note) {
 		return {
 			i: note.interval.id,
 			d: Math.round(note.delay * 4),
 			l: Math.round(note.len * 4),
-			h: Math.round(note._hz * 16),
+			h: Math.round(note._hz * HZ_MUL),
 			m: note.mute,
 			v: note.volume - 50,
+			hd: note.hidden ? 1 : 0,
+			pt: note._pitchThick,
+			lt: note._linkThick,
+			lo: note._linkOpacity,
+			no: note._noteOpacity,
+			tk: note._tick,
 			s: note.childNotes.children.map(x => this.sub2json(x))
 		}
 	}
-
+	// 从 JSON 反序列化根音符字符串重建工程（自动检测纯 JSON 或 crush 压缩格式）
+	// デシリアライズ：JSON文字列からプロジェクトを再構築（純粋JSONまたはcrush圧縮形式を自動検出）
+	// Deserialize from JSON string: rebuild project (auto-detect plain JSON or crush-compressed format)
 	static deserialize(d) {
-		const u = JSON.parse(JSONCrush.uncrush(decodeURIComponent(d)))
-		console.log("loading", u)
+		let u
+		// 先尝试纯 JSON（历史快照），失败则尝试 URL解码+JSONCrush解压（分享/文件）
+		// まず純粋JSON（履歴スナップショット）を試行、失敗時はURLデコード+JSONCrush解凍（共有/ファイル）
+		// Try plain JSON first (history snapshots); on failure, try URL-decode + JSONCrush decompress (sharing/file)
+		try { u = JSON.parse(d) }
+		catch { u = JSON.parse(JSONCrush.uncrush(decodeURIComponent(d))) }
+		// 版本感知：v2 用 HZ_MUL=256，旧文件用 16
+		// バージョン認識：v2はHZ_MUL=256、旧ファイルは16を使用
+		// Version-aware: v2 uses HZ_MUL=256, old files use 16
+		const hzDiv = (u.s && u.s.v >= 2) ? HZ_MUL : 16
 		
-		if (u.s) {
+		if (u.s && u.s.b != null) {   // 仅当包含实际工程设置（beat/tonic）而非仅版本标记 / 実際のプロジェクト設定（beat/tonic）を含む場合のみ、バージョンタグだけではない / Only when containing actual project settings (beat/tonic), not just version marker
 			grid.beat = u.s.b
 			grid.tonic = u.s.t
 			grid.loopStart.x(t2x(u.s.s || 0))
@@ -57,30 +104,66 @@ export class Serializer {
 			$(`#config-tone>option[value='${u.s.i || "salamander-piano"}']`).selected = true
 			$('#config-tone').dispatchEvent(new Event('change'))
 		}
+		// 恢复 layer 级透明度，避免 Ctrl+Z 后音符透明度丢失
+		if (u.s && u.s.o != null) rootlayer.opacity(u.s.o)
 		if (!u.n) return
 		for (const n of u.n) {
-			this.json2root(n)
+			const p = new RootNote(stage, n.x / 4 || 0, hz2y(n.h / hzDiv), n.l / 4, null, null, n.tk)
+			p.mute = n.m || false
+			p.volume = 50 + (n.v || 0)
+			// 恢复外观属性 / 外観属性を復元 / Restore visual properties
+			p._pitchThick = n.pt || p._pitchThick
+			p._linkThick = n.lt || p._linkThick
+			p._linkOpacity = n.lo || p._linkOpacity
+			p._noteOpacity = n.no ?? p._noteOpacity
+			p._tick = n.tk || p._tick
+			p.pitchline.strokeWidth(p._pitchThick)
+			p.pitchline.opacity(p._noteOpacity)
+			if (p.mark) p.mark.opacity(p._noteOpacity)
+			// 恢复隐藏状态（必须在 pitchline.opacity 之后，否则会被覆盖）// 非表示状態を復元（pitchline.opacityの後でないと上書きされる）// Restore hidden state (must be after pitchline.opacity to avoid overwrite)
+			p.hidden = !!(n.hd)
+			if (p._linkThick !== 1 || p._linkOpacity !== 1) p.applyLinkStyle()
+			rootlayer.add(p)
+			for (const m of n.s || []) {
+				this.json2sub(p, m, hzDiv)
+			}
 		}
 	}
-	
-	static json2root(n) {
-		const p = new RootNote(stage, n.x / 4 || 0, hz2y(n.h / 16), n.l / 4)
-		p.mute = n.m || false
-		p.volume = 50 + (n.v || 0)
-		rootlayer.add(p)
-		for (const m of n.s || []) {
-			this.json2sub(p, m)
-		}
-		return p
-	}
-	
-	static json2sub(p, m) {
-		const q = p.addNote(m.l / 4, pitchIntervals[(m.i || 0) + "d"], m.d / 4 || 0)
+
+	// 从 JSON 递归重建子音符
+	// JSONからサブ音符を再帰的に再構築
+	// Recursively rebuild sub-notes from JSON
+	static json2sub(p, m, hzDiv = 16) {
+		const id = m.i || 0
+		// 音程键算法：将整数 ID 映射到音程字典的字符串键
+		//   id ≥ 100 → "c(id-100)"（正向自定义） / 正方向カスタム / positive custom
+		//   id ≤ -100 → "-c(-id-100)"（反向自定义） / 逆方向カスタム / negative custom  
+		//   否则 → "id d"（标准维度）
+		// 音程キーアルゴリズム：整数IDを音程辞書の文字列キーにマッピング
+		// Interval key algorithm: maps integer ID to string key in the interval dictionary
+		let key
+		if (id >= 100) key = 'c' + (id - 100)
+		else if (id <= -100) key = '-c' + (-id - 100)
+		else key = id + 'd'
+		const interval = pitchIntervals[key]
+		if (!interval) return
+		const q = p.addNote(m.l / 4, interval, m.d / 4 || 0)
 		q.mute = m.m || false
 		q.volume = 50 + (m.v || 0)
-		if (m.h) q.hz = m.h / 16
+		if (m.h) q.hz = m.h / hzDiv
+		// 恢复外观属性 / 外観属性を復元 / Restore visual properties
+		q._pitchThick = m.pt || q._pitchThick
+		q._linkThick = m.lt || q._linkThick
+		q._linkOpacity = m.lo || q._linkOpacity
+		q._noteOpacity = m.no ?? q._noteOpacity
+		q._tick = m.tk || q._tick
+		q.pitchline.strokeWidth(q._pitchThick)
+		q.pitchline.opacity(q._noteOpacity)
+		// 恢复隐藏状态（必须在 pitchline.opacity 之后，否则会被覆盖）
+		q.hidden = !!(m.hd)
+		if (q.linkLine) q.linkLine.opacity(q._linkOpacity)
 		for (const l of m.s || []) {
-			this.json2sub(q, l)
+			this.json2sub(q, l, hzDiv)
 		}
 	}
 }

--- a/js/shasav.js
+++ b/js/shasav.js
@@ -215,6 +215,55 @@ for (const el of $$('.play-this-btn')) {
 	})
 }
 
+// 工程保存到文件
+// プロジェクトをファイルに保存 // Save project to file
+$('#save-project-btn').addEventListener('click', async e => {
+	const d = await Serializer.serialize(true)
+	if (window.showSaveFilePicker) {
+		try {
+			const handle = await window.showSaveFilePicker({
+				suggestedName: 'project.naf',
+				types: [{
+					description: 'Nafchan Project',
+					accept: { 'text/plain': ['.naf', '.txt'] }
+				}]
+			})
+			const writable = await handle.createWritable()
+			await writable.write(d)
+			await writable.close()
+			return
+		} catch (err) {
+			if (err.name === 'AbortError') return // 用户取消
+		}
+	}
+	// 回退：浏览器不支持 showSaveFilePicker
+	const blob = new Blob([d], { type: 'text/plain' })
+	const url = URL.createObjectURL(blob)
+	const a = document.createElement('a')
+	a.href = url; a.download = 'project.naf'
+	document.body.appendChild(a); a.click(); document.body.removeChild(a)
+	URL.revokeObjectURL(url)
+})
+
+// 从文件加载工程
+// ファイルからプロジェクトを読み込み // Load project from file
+$('#load-project-btn').addEventListener('click', e => {
+	const input = document.createElement('input')
+	input.type = 'file'; input.accept = '.naf,.txt'
+	input.onchange = async () => {
+		const file = input.files[0]
+		if (!file) return
+		const text = await file.text()
+		history.snapshot()
+		rootlayer.destroyChildren()
+		Tone.Transport.cancel()
+		await Serializer.deserialize(text.trim())
+		rootlayer.draw()
+		grid.autoLoop()
+	}
+	input.click()
+})
+
 if (location.search !== '') {
 	Serializer.deserialize(location.search.slice(1))
 }

--- a/server.py
+++ b/server.py
@@ -1,0 +1,37 @@
+import http.server
+import mimetypes
+from urllib.parse import urlparse
+
+# 修复 Windows 上 .js 和 .mjs 文件的 MIME 类型
+mimetypes.add_type('application/javascript', '.js')
+mimetypes.add_type('application/javascript', '.mjs')
+mimetypes.add_type('text/css', '.css')
+mimetypes.add_type('audio/ogg', '.ogg')
+mimetypes.add_type('audio/mpeg', '.mp3')
+mimetypes.add_type('font/otf', '.otf')
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    # 直接覆盖 extensions_map，因为在 Windows 上 mimetypes 初始化不完整
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        '.js': 'application/javascript',
+        '.mjs': 'application/javascript',
+        '.css': 'text/css',
+        '.ogg': 'audio/ogg',
+        '.mp3': 'audio/mpeg',
+        '.otf': 'font/otf',
+    }
+
+    def do_GET(self):
+        # 处理预览环境注入的 @vite/client 请求
+        path = urlparse(self.path).path
+        if path == '/@vite/client':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/javascript')
+            self.end_headers()
+            self.wfile.write(b'')
+            return
+        super().do_GET()
+
+if __name__ == '__main__':
+    http.server.test(Handler, port=3300)

--- a/style.css
+++ b/style.css
@@ -24,7 +24,6 @@
 }
 
 body {
-	position: fixed;
 	margin: 0;
 	padding: 0;
 	overflow: hidden;
@@ -55,17 +54,20 @@ i {
 }
 
 canvas {
-	image-rendering: pixelated;
+	image-rendering: auto;
+}
+#sequencer, #sequencer * {
+	max-width: none;
 }
 
 #sequencer {
 	width: 100vw;
-	height: 100lvh;
+	height: 100dvh;
 	background-color: #676681;
 }
 
 header {
-	padding-block-end: calc(100lvh - 100dvh);
+	padding-block-end: 0;
 }
 
 #config {


### PR DESCRIPTION
以下の変更を行いました：

1.Python 組み込みの http.server を使用した静的ファイルサーバーを追加

2.疑わしいバグを修正。grid.js のコンストラクタにデフォルト値 tonic = 440、beat = 500 を追加し、ページ初回ロード時にキャンバスにグリッド線が表示されるようにした

3.naf 形式でのプロジェクト保存/読み込みをサポート。以下のファイルを修正：
serialize.js —履歴スナップショットはプレーンな JSON を使用し、共有/ファイル出力には JSONCrush 圧縮を適用（一部の保存形式は今後の機能拡張に対応するためのものであり、不要と判断した場合は削除可能）
shasav.js — 保存/読み込みボタンのイベントを追加
index.html — 設定パネルの下部に「保存」「読み込み」ボタンを追加
grid.js — プロジェクト読み込み後、ループ矢印を自動的に最左/最右の音符に位置合わせ
i18n.js — ファイル保存/読み込みに関する翻訳を3言語に追加

4.canvas が * { max-width: 100%; } によって圧縮され、表示がぼやけてしまったため、style.css を修正しました。

上記の変更につきまして、ご確認いただき、また何かご意見がございましたらお知らせください。その後、最新のバージョンをベースにさらなる改善案をご提案させていただきます。不具合を生じさせないよう、慎重に対応いたしますので、どうぞよろしくお願いいたします。